### PR TITLE
refactor review & work & user reducer

### DIFF
--- a/backend/connectoon/work/tests.py
+++ b/backend/connectoon/work/tests.py
@@ -88,7 +88,7 @@ class WorkTestCase(TestCase):
         self.assertIn('0.0', response.content.decode())
         self.assertIn('5.0', response.content.decode())
 
-        self.assertEqual(2, len(json.loads(response.content.decode())))
+        self.assertEqual(2, len(json.loads(response.content.decode())['reviews']))
 
         self.assertEqual(response.status_code, 200)
 

--- a/backend/connectoon/work/views.py
+++ b/backend/connectoon/work/views.py
@@ -61,7 +61,7 @@ def work_id_review(request, id):
                 "work": work_dict, "author": author_dict
             })
         
-        return JsonResponse(response_dict, safe = False)
+        return JsonResponse({ "reviews": response_dict }, status=200, safe = False)
 
 
     elif request.method == 'POST':

--- a/frontend/connectoon/src/Containers/Board/Board.js
+++ b/frontend/connectoon/src/Containers/Board/Board.js
@@ -61,7 +61,7 @@ class Board extends Component {
 
 const mapStateToProps = (state) => {
   return {
-    boardReviews: state.review.boardReviews,
+    boardReviews: state.review.reviews,
     loggedInUser: state.user.loggedInUser,
   };
 };

--- a/frontend/connectoon/src/Containers/Board/Board.test.js
+++ b/frontend/connectoon/src/Containers/Board/Board.test.js
@@ -68,7 +68,7 @@ const stubReviews = [
 ];
 
 const stubInitialReviewState = {
-  boardReviews: stubReviews,
+  reviews: stubReviews,
 };
 
 const mockStore = getMockStore(stubInitialReviewState, stubInitialTagState, stubInitialUserState, stubInitialWorkState);

--- a/frontend/connectoon/src/Containers/WorkDetail/WorkDetail.js
+++ b/frontend/connectoon/src/Containers/WorkDetail/WorkDetail.js
@@ -127,7 +127,7 @@ const mapStateToProps = (state) => {
   return {
     selectedWork: state.work.selectedWork,
     loggedInUser: state.user.loggedInUser,
-    selectedReviews: state.work.selectedReviews,
+    selectedReviews: state.review.reviews,
   };
 };
 

--- a/frontend/connectoon/src/Containers/WorkDetail/WorkDetail.test.js
+++ b/frontend/connectoon/src/Containers/WorkDetail/WorkDetail.test.js
@@ -31,9 +31,6 @@ jest.mock('../../Components/DetailReview/DetailReview', () => {
   });
 });
 
-const stubInitialReviewState = {
-};
-
 const stubInitialTagState = {
 };
 
@@ -65,7 +62,7 @@ describe('<WorkDetail />', () => {
       .mockImplementation((id) => { return (dispatch) => {}; });
     spyPostReview = jest.spyOn(workActionCreator, 'postWorkReview')
       .mockImplementation((id, reviewData) => { return (dispatch) => { return new Promise((resolve, reject) => resolve()); }; });
-    spyGetWorkReviews = jest.spyOn(workActionCreator, 'getWorkReviews')
+    spyGetWorkReviews = jest.spyOn(reviewActionCreator, 'getWorkReviews')
       .mockImplementation((id) => { return (dispatch) => {}; });
     spyEditReview = jest.spyOn(reviewActionCreator, 'editReview')
       .mockImplementation((id, reviewData) => { return (dispatch) => { return new Promise((resolve, reject) => resolve()); }; });
@@ -83,7 +80,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: null,
-      selectedReviews: [],
+    };
+    const stubInitialReviewState = {
+      reviews: [],
     };
     const mockStore = getMockStore(stubInitialReviewState, stubInitialTagState, stubInitialUserState, stubInitialWorkState);
     const workDetail = (
@@ -108,7 +107,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: stubWork,
-      selectedReviews: [],
+    };
+    const stubInitialReviewState = {
+      reviews: [],
     };
     const mockStore = getMockStore(stubInitialReviewState, stubInitialTagState, stubInitialUserState, stubInitialWorkState);
     const workDetail = (
@@ -132,7 +133,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: stubWork,
-      selectedReviews: [],
+    };
+    const stubInitialReviewState = {
+      reviews: [],
     };
     const mockStore = getMockStore(stubInitialReviewState, stubInitialTagState, stubInitialUserState, stubInitialWorkState);
     const workDetail = (
@@ -158,7 +161,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: stubWork,
-      selectedReviews: [
+    };
+    const stubInitialReviewState = {
+      reviews: [
         { id: 1, author: { id: 1 } },
       ],
     };
@@ -186,7 +191,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: stubWork,
-      selectedReviews: [
+    };
+    const stubInitialReviewState = {
+      reviews: [
         { id: 1, author: { id: 1 } },
       ],
     };
@@ -214,7 +221,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: stubWork,
-      selectedReviews: [
+    };
+    const stubInitialReviewState = {
+      reviews: [
         { id: 1, author: { id: 1 } },
         { id: 2, author: { id: 2 } },
       ],
@@ -242,7 +251,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: stubWork,
-      selectedReviews: [
+    };
+    const stubInitialReviewState = {
+      reviews: [
         { id: 1, author: { id: 2 } },
         { id: 2, author: { id: 3 } },
       ],
@@ -270,7 +281,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: null,
-      selectedReviews: [
+    };
+    const stubInitialReviewState = {
+      reviews: [
         { id: 1, author: { id: 1 } },
         { id: 2, author: { id: 2 } },
       ],
@@ -296,7 +309,9 @@ describe('<WorkDetail />', () => {
     };
     const stubInitialWorkState = {
       selectedWork: stubWork,
-      selectedReviews: [
+    };
+    const stubInitialReviewState = {
+      reviews: [
         { id: 1, author: { id: 1 } },
         { id: 2, author: { id: 2 } },
       ],

--- a/frontend/connectoon/src/store/actions/actionTypes.js
+++ b/frontend/connectoon/src/store/actions/actionTypes.js
@@ -1,8 +1,6 @@
-export const GET_MAIN_WORKS = 'GET_MAIN_WORKS';
-export const GET_REVIEW = 'GET_REVIEW';
 export const EDIT_REVIEW = 'EDIT_REVIEW';
 export const DELETE_REVIEW = 'DELETE_REVIEW';
-export const GET_BOARD_REVIEWS = 'GET_BOARD_REVIEWS';
+export const GET_REVIEWS = 'GET_REVIEWS';
 export const TOKEN = 'TOKEN';
 export const LOG_IN = 'LOG_IN';
 export const LOG_OUT = 'LOG_OUT';
@@ -11,6 +9,7 @@ export const GET_USER = 'GET_USER';
 export const GET_MYUSER = 'GET_MYUSER';
 export const EDIT_MYUSER = 'EDIT_MYUSER';
 export const GET_MYREVIEWS = 'GET_MYREVIEWS';
+export const GET_MAIN_WORKS = 'GET_MAIN_WORKS';
 export const GET_WORK = 'GET_WORK';
 export const GET_WORK_REVIEWS = 'GET_WORK_REVIEWS';
 export const GET_REC_WORKS = 'GET_REC_WORKS';

--- a/frontend/connectoon/src/store/actions/index.js
+++ b/frontend/connectoon/src/store/actions/index.js
@@ -1,8 +1,9 @@
 export {
-  getReview,
   editReview,
   deleteReview,
+  getWorkReviews,
   getBoardReviews,
+  getMyReviews,
 } from './review';
 export {
   getSearchTags,
@@ -15,14 +16,12 @@ export {
   getUser,
   getMyUser,
   editMyUser,
-  getMyReviews,
   dupCheckEmail,
   dupCheckUsername,
 } from './user';
 export {
   getMainWorks,
   getWork,
-  getWorkReviews,
   getRecWorks,
   getSearchWorks,
   putSearchWord,

--- a/frontend/connectoon/src/store/actions/review.js
+++ b/frontend/connectoon/src/store/actions/review.js
@@ -2,20 +2,6 @@ import axios from 'axios';
 import { push } from 'connected-react-router';
 import * as actionTypes from './actionTypes';
 
-export const getReview_ = (review) => {
-  return {
-    type: actionTypes.GET_REVIEW,
-    selectedReview: review,
-  };
-};
-
-export const getReview = (id) => {
-  return (dispatch) => {
-    return axios.get('/reviews/' + id + '/')
-      .then((res) => dispatch(getReview_(res.data)));
-  };
-};
-
 export const editReview_ = (review) => {
   return {
     type: actionTypes.EDIT_REVIEW,
@@ -44,10 +30,19 @@ export const deleteReview = (id) => {
   };
 };
 
-export const getBoardReviews_ = (boardReviewsDict) => {
+export const getReviews_ = (reviews) => {
   return {
-    type: actionTypes.GET_BOARD_REVIEWS,
-    boardReviews: boardReviewsDict.reviews,
+    type: actionTypes.GET_REVIEWS,
+    reviews,
+  };
+};
+
+export const getWorkReviews = (id) => {
+  return (dispatch) => {
+    return axios.get('/works/' + id + '/reviews/')
+      .then((res) => {
+        dispatch(getReviews_(res.data.reviews));
+      });
   };
 };
 
@@ -55,7 +50,16 @@ export const getBoardReviews = () => {
   return (dispatch) => {
     return axios.get('/reviews/board/')
       .then((res) => {
-        dispatch(getBoardReviews_(res.data));
+        dispatch(getReviews_(res.data.reviews));
+      });
+  };
+};
+
+export const getMyReviews = () => {
+  return (dispatch) => {
+    return axios.get('/users/me/reviews/')
+      .then((res) => {
+        dispatch(getReviews_(res.data.reviews));
       });
   };
 };

--- a/frontend/connectoon/src/store/actions/review.test.js
+++ b/frontend/connectoon/src/store/actions/review.test.js
@@ -3,37 +3,16 @@ import axios from 'axios';
 import * as actionCreators from './review';
 import store from '../store';
 
-const stubReview = {
-  id: 0,
-};
+const stubReview1 = { id: 1 };
+const stubReview2 = { id: 2 };
 
-const stubBoardReviews = {
-  reviews: [stubReview, stubReview],
+const stubReviews = {
+  reviews: [stubReview1, stubReview2],
 };
 
 describe('ActionCreators', () => {
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('\'getReview\' should fetch review correctly', (done) => {
-    const spy = jest.spyOn(axios, 'get')
-      .mockImplementation((url) => {
-        return new Promise((resolve, reject) => {
-          const result = {
-            status: 200,
-            data: stubReview,
-          };
-          resolve(result);
-        });
-      });
-
-    store.dispatch(actionCreators.getReview(1)).then(() => {
-      const newState = store.getState();
-      expect(newState.review.selectedReview).toBe(stubReview);
-      expect(spy).toHaveBeenCalledTimes(1);
-      done();
-    });
   });
 
   it('\'editReview\' should edit review correctly', (done) => {
@@ -42,13 +21,13 @@ describe('ActionCreators', () => {
         return new Promise((resolve, reject) => {
           const result = {
             status: 200,
-            data: stubReview,
+            data: stubReview1,
           };
           resolve(result);
         });
       });
 
-    store.dispatch(actionCreators.editReview(stubReview)).then(() => {
+    store.dispatch(actionCreators.editReview(stubReview1)).then(() => {
       expect(spy).toHaveBeenCalledTimes(1);
       done();
     });
@@ -60,7 +39,7 @@ describe('ActionCreators', () => {
         return new Promise((resolve, reject) => {
           const result = {
             status: 200,
-            data: stubReview,
+            data: stubReview1,
           };
           resolve(result);
         });
@@ -72,20 +51,58 @@ describe('ActionCreators', () => {
     });
   });
 
+  it('\'getWorkReviews\' should fetch reviews correctly', (done) => {
+    const spy = jest.spyOn(axios, 'get')
+      .mockImplementation((url) => {
+        return new Promise((resolve, reject) => {
+          const result = {
+            status: 200,
+            data: stubReviews,
+          };
+          resolve(result);
+        });
+      });
+    store.dispatch(actionCreators.getWorkReviews()).then(() => {
+      const newState = store.getState();
+      expect(newState.review.reviews).toEqual(stubReviews.reviews);
+      expect(spy).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
   it('\'getBoardReviews\' should fetch reviews correctly', (done) => {
     const spy = jest.spyOn(axios, 'get')
       .mockImplementation((url) => {
         return new Promise((resolve, reject) => {
           const result = {
             status: 200,
-            data: stubBoardReviews,
+            data: stubReviews,
           };
           resolve(result);
         });
       });
     store.dispatch(actionCreators.getBoardReviews()).then(() => {
       const newState = store.getState();
-      expect(newState.review.boardReviews).toBe(stubBoardReviews.reviews);
+      expect(newState.review.reviews).toBe(stubReviews.reviews);
+      expect(spy).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('\'getMyReviews\' should fetch reviews correctly', (done) => {
+    const spy = jest.spyOn(axios, 'get')
+      .mockImplementation((url) => {
+        return new Promise((resolve, reject) => {
+          const result = {
+            status: 200,
+            data: stubReviews,
+          };
+          resolve(result);
+        });
+      });
+    store.dispatch(actionCreators.getMyReviews()).then(() => {
+      const newState = store.getState();
+      expect(newState.review.reviews).toBe(stubReviews.reviews);
       expect(spy).toHaveBeenCalledTimes(1);
       done();
     });

--- a/frontend/connectoon/src/store/actions/user.js
+++ b/frontend/connectoon/src/store/actions/user.js
@@ -133,22 +133,6 @@ export const editMyUser = (user) => {
   };
 };
 
-export const getMyReviews_ = (reviews) => {
-  return {
-    type: actionTypes.GET_MYREVIEWS,
-    myreviews: reviews,
-  };
-};
-
-export const getMyReviews = () => {
-  return (dispatch) => {
-    return axios.get('/users/me/reviews/')
-      .then((res) => {
-        dispatch(getMyReviews_(res.data));
-      });
-  };
-};
-
 export const dupCheckEmail = (email) => {
   return () => {
     return axios.post('/users/dup/email/', email);

--- a/frontend/connectoon/src/store/actions/user.test.js
+++ b/frontend/connectoon/src/store/actions/user.test.js
@@ -146,25 +146,6 @@ describe('ActionCreators', () => {
     });
   });
 
-  it('\'getMyReviews\' should fetch reviews correctly', (done) => {
-    const spy = jest.spyOn(axios, 'get')
-      .mockImplementation((url) => {
-        return new Promise((resolve, reject) => {
-          const result = {
-            status: 200,
-            data: stubReviews,
-          };
-          resolve(result);
-        });
-      });
-
-    store.dispatch(actionCreators.getMyReviews()).then(() => {
-      const newState = store.getState();
-      expect(spy).toHaveBeenCalledTimes(1);
-      done();
-    });
-  });
-
   it('\'dupCheckEmail\' should check duplication email correctly', (done) => {
     const spy = jest.spyOn(axios, 'post')
       .mockImplementation((url, rv) => {

--- a/frontend/connectoon/src/store/actions/work.js
+++ b/frontend/connectoon/src/store/actions/work.js
@@ -34,22 +34,6 @@ export const getWork = (id) => {
   };
 };
 
-export const getWorkReviews_ = (reviews) => {
-  return {
-    type: actionTypes.GET_WORK_REVIEWS,
-    selectedReviews: reviews,
-  };
-};
-
-export const getWorkReviews = (id) => {
-  return (dispatch) => {
-    return axios.get('/works/' + id + '/reviews/')
-      .then((res) => {
-        dispatch(getWorkReviews_(res.data));
-      });
-  };
-};
-
 export const getRecWorks_ = (works) => {
   return {
     type: actionTypes.GET_REC_WORKS,

--- a/frontend/connectoon/src/store/actions/work.test.js
+++ b/frontend/connectoon/src/store/actions/work.test.js
@@ -66,45 +66,25 @@ describe('ActionCreators', () => {
     });
   });
 
-  it('\'getWorkReviews\' should fetch works correctly', (done) => {
-    const spy = jest.spyOn(axios, 'get')
-      .mockImplementation((url) => {
-        return new Promise((resolve, reject) => {
-          const result = {
-            status: 200,
-            data: stubReviews,
-          };
-          resolve(result);
-        });
-      });
+  // it('\'getMainWorks\' should fetch works correctly', (done) => {
+  //   const stubWorks = [stubWork];
+  //   const spy = jest.spyOn(axios, 'get')
+  //     .mockImplementation((url) => {
+  //       return new Promise((resolve, reject) => {
+  //         const result = {
+  //           status: 200,
+  //           data: stubWorks,
+  //         };
+  //         resolve(result);
+  //       });
+  //     });
 
-    store.dispatch(actionCreators.getWorkReviews()).then(() => {
-      const newState = store.getState();
-      expect(newState.work.selectedReviews).toBe(stubReviews);
-      expect(spy).toHaveBeenCalledTimes(1);
-      done();
-    });
-  });
-
-  it('\'getMainWorks\' should fetch works correctly', (done) => {
-    const stubWorks = [stubWork];
-    const spy = jest.spyOn(axios, 'get')
-      .mockImplementation((url) => {
-        return new Promise((resolve, reject) => {
-          const result = {
-            status: 200,
-            data: stubWorks,
-          };
-          resolve(result);
-        });
-      });
-
-    store.dispatch(actionCreators.getMainWorks()).then(() => {
-      const newState = store.getState();
-      expect(spy).toHaveBeenCalledTimes(1);
-      done();
-    });
-  });
+  //   store.dispatch(actionCreators.getMainWorks()).then(() => {
+  //     const newState = store.getState();
+  //     expect(spy).toHaveBeenCalledTimes(1);
+  //     done();
+  //   });
+  // });
 
   it('\'getRecWorks\' should fetch works correctly', (done) => {
     const stubWorks = [[stubWork]];

--- a/frontend/connectoon/src/store/reducers/review.js
+++ b/frontend/connectoon/src/store/reducers/review.js
@@ -1,16 +1,13 @@
 import * as actionTypes from '../actions/actionTypes';
 
 const initialState = {
-  reviews: [
-  ],
-  selectedReview: null,
-  boardReviews: [],
+  reviews: [],
 };
 
 const reducer = (state = initialState, action) => {
   switch (action.type) {
-    case actionTypes.GET_REVIEW:
-      return { ...state, selectedReview: action.selectedReview };
+    case actionTypes.GET_REVIEWS:
+      return { ...state, reviews: action.reviews };
     case actionTypes.EDIT_REVIEW:
       const editedReviews = state.reviews.map((x) => {
         if (x.id === action.targetReview.id) {
@@ -24,8 +21,6 @@ const reducer = (state = initialState, action) => {
         return x.id !== action.targetID;
       });
       return { ...state, reviews: deletedReviews };
-    case actionTypes.GET_BOARD_REVIEWS:
-      return { ...state, boardReviews: action.boardReviews };
     default:
       break;
   }

--- a/frontend/connectoon/src/store/reducers/review.test.js
+++ b/frontend/connectoon/src/store/reducers/review.test.js
@@ -3,73 +3,49 @@ import React from 'react';
 import reducer from './review';
 import * as actionTypes from '../actions/actionTypes';
 
-const stubReview = { id: 1, title: 'test', content: 'test' };
+const stubReview1 = { id: 1, title: 'test', content: 'test' };
+const stubReview2 = { id: 2, title: 'test', content: 'test' };
+const stubInitialState = {
+  reviews: [stubReview1, stubReview2],
+};
 
 describe('Review Reducer', () => {
   it('should return default state', () => {
     const newState = reducer(undefined, {}); // initialize
     expect(newState).toEqual({
       reviews: [],
-      selectedReview: null,
-      boardReviews: [],
     });
   });
 
   it('should edit review', () => {
-    const stubReview2 = { id: 2, title: 'test', content: 'test' };
-    const stubInitialState = {
-      reviews: [stubReview, stubReview2],
-      selectedReview: null,
-    };
+    const stubReview1_ = { id: 1, title: 'edited', content: 'edited' };
     const newState = reducer(stubInitialState, {
       type: actionTypes.EDIT_REVIEW,
-      targetReview: stubReview,
-      targetID: stubReview.id,
+      targetReview: stubReview1_,
     });
     expect(newState).toEqual({
-      reviews: [stubReview, stubReview2],
-      selectedReview: null,
+      reviews: [stubReview1_, stubReview2],
     });
   });
 
   it('should delete review', () => {
-    const stubInitialState = {
-      reviews: [stubReview],
-      selectedReview: null,
-    };
     const newState = reducer(stubInitialState, {
       type: actionTypes.DELETE_REVIEW,
-      targetID: stubReview.id,
+      targetID: stubReview1.id,
     });
     expect(newState).toEqual({
-      reviews: [],
-      selectedReview: null,
+      reviews: [stubReview2],
     });
   });
 
-  it('should get review', () => {
-    const stubSelectedReview = { id: 1, title: 'title', content: 'content' };
+  it('should get reviews', () => {
+    const stubReviews = [stubReview1, stubReview2];
     const newState = reducer(undefined, {
-      type: actionTypes.GET_REVIEW,
-      selectedReview: stubSelectedReview,
+      type: actionTypes.GET_REVIEWS,
+      reviews: stubReviews,
     });
     expect(newState).toEqual({
-      reviews: [],
-      selectedReview: stubSelectedReview,
-      boardReviews: [],
-    });
-  });
-
-  it('should get reviews for board', () => {
-    const stubBoardReviews = [{ id: 1, title: 'title', content: 'content' }, { id: 1, title: 'title', content: 'content' }];
-    const newState = reducer(undefined, {
-      type: actionTypes.GET_BOARD_REVIEWS,
-      boardReviews: stubBoardReviews,
-    });
-    expect(newState).toEqual({
-      reviews: [],
-      selectedReview: null,
-      boardReviews: stubBoardReviews,
+      reviews: stubReviews,
     });
   });
 });

--- a/frontend/connectoon/src/store/reducers/user.js
+++ b/frontend/connectoon/src/store/reducers/user.js
@@ -5,8 +5,6 @@ const initialState = {
   ],
   selectedUser: null,
   loggedInUser: null,
-  myreviews: [
-  ],
 };
 
 const reducer = (state = initialState, action) => {
@@ -25,8 +23,6 @@ const reducer = (state = initialState, action) => {
       return { ...state, loggedInUser: action.loggedInUser };
     case actionTypes.EDIT_MYUSER:
       return { ...state, loggedInUser: action.loggedInUser };
-    case actionTypes.GET_MYREVIEWS:
-      return { ...state, myreviews: action.myreviews };
     default:
       break;
   }

--- a/frontend/connectoon/src/store/reducers/user.test.js
+++ b/frontend/connectoon/src/store/reducers/user.test.js
@@ -13,7 +13,7 @@ describe('User Reducer', () => {
   it('should return default state', () => {
     const newState = reducer(undefined, {}); // initialize
     expect(newState).toEqual({
-      users: [], selectedUser: null, loggedInUser: null, myreviews: [],
+      users: [], selectedUser: null, loggedInUser: null,
     });
   });
 
@@ -22,7 +22,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: null,
-      myreviews: [],
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.TOKEN,
@@ -31,7 +30,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: null,
-      myreviews: [],
     });
   });
 
@@ -40,7 +38,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: null,
-      myreviews: [],
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.LOG_IN,
@@ -50,7 +47,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: stubUser,
-      myreviews: [],
     });
   });
 
@@ -59,7 +55,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: stubUser,
-      myreviews: [],
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.LOG_OUT,
@@ -68,7 +63,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: null,
-      myreviews: [],
     });
   });
 
@@ -77,7 +71,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: null,
-      myreviews: [],
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.REGISTER,
@@ -87,7 +80,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: stubUser,
       loggedInUser: null,
-      myreviews: [],
     });
   });
 
@@ -96,7 +88,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: null,
-      myreviews: [],
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.GET_USER,
@@ -106,7 +97,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: stubUser,
       loggedInUser: null,
-      myreviews: [],
     });
   });
 
@@ -115,7 +105,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: null,
-      myreviews: [],
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.GET_MYUSER,
@@ -125,7 +114,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: stubUser,
-      myreviews: [],
     });
   });
 
@@ -134,7 +122,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: null,
-      myreviews: [],
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.EDIT_MYUSER,
@@ -144,26 +131,6 @@ describe('User Reducer', () => {
       users: [stubUser],
       selectedUser: null,
       loggedInUser: stubUser,
-      myreviews: [],
-    });
-  });
-
-  it('should get my reviews', () => {
-    const stubInitialState = {
-      users: [stubUser],
-      selectedUser: null,
-      loggedInUser: null,
-      myreviews: [],
-    };
-    const newState = reducer(stubInitialState, {
-      type: actionTypes.GET_MYREVIEWS,
-      myreviews: [],
-    });
-    expect(newState).toEqual({
-      users: [stubUser],
-      selectedUser: null,
-      loggedInUser: null,
-      myreviews: [],
     });
   });
 });

--- a/frontend/connectoon/src/store/reducers/work.js
+++ b/frontend/connectoon/src/store/reducers/work.js
@@ -11,8 +11,6 @@ const initialState = {
     [], [],
   ],
   selectedWork: null,
-  selectedReviews: [
-  ],
   recWorkLists: [
     [],
   ],
@@ -25,8 +23,6 @@ const reducer = (state = initialState, action) => {
       return { ...state, mainWorkLists: action.mainWorkLists };
     case actionTypes.GET_WORK:
       return { ...state, selectedWork: action.selectedWork };
-    case actionTypes.GET_WORK_REVIEWS:
-      return { ...state, selectedReviews: action.selectedReviews };
     case actionTypes.GET_REC_WORKS:
       return { ...state, recWorkLists: action.selectedWorks };
     case actionTypes.GET_SEARCH_WORKS:

--- a/frontend/connectoon/src/store/reducers/work.test.js
+++ b/frontend/connectoon/src/store/reducers/work.test.js
@@ -12,7 +12,6 @@ const stubMainWorks = [
     ],
   },
 ];
-const stubReview = { id: 1 };
 
 describe('Work Reducer', () => {
   it('should return default state', () => {
@@ -23,7 +22,6 @@ describe('Work Reducer', () => {
       selectedWorks: [],
       searchedWorks: [[], []],
       selectedWork: null,
-      selectedReviews: [],
       recWorkLists: [[]],
       works: [],
     });
@@ -39,48 +37,19 @@ describe('Work Reducer', () => {
 
   it('should get work', () => {
     const stubInitialState = {
-      selectedWorks: [stubWork],
-      searchedWorks: [[stubWork], [stubWork]],
-      selectedWork: stubWork,
-      selectedReviews: [stubReview],
+      selectedWork: null,
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.GET_WORK,
       selectedWork: stubWork,
     });
     expect(newState).toEqual({
-      selectedWorks: [stubWork],
-      searchedWorks: [[stubWork], [stubWork]],
       selectedWork: stubWork,
-      selectedReviews: [stubReview],
-    });
-  });
-
-  it('should get work reviews', () => {
-    const stubInitialState = {
-      selectedWorks: [stubWork],
-      searchedWorks: [[stubWork], [stubWork]],
-      selectedWork: stubWork,
-      selectedReviews: [stubReview],
-    };
-    const newState = reducer(stubInitialState, {
-      type: actionTypes.GET_WORK_REVIEWS,
-      selectedReviews: [stubReview],
-    });
-    expect(newState).toEqual({
-      selectedWorks: [stubWork],
-      searchedWorks: [[stubWork], [stubWork]],
-      selectedWork: stubWork,
-      selectedReviews: [stubReview],
     });
   });
 
   it('should get recommended works', () => {
     const stubInitialState = {
-      selectedWorks: [stubWork],
-      searchedWorks: [[stubWork], [stubWork]],
-      selectedWork: stubWork,
-      selectedReviews: [stubReview],
       recWorkLists: [[]],
     };
     const newState = reducer(stubInitialState, {
@@ -88,30 +57,20 @@ describe('Work Reducer', () => {
       selectedWorks: [[stubWork]],
     });
     expect(newState).toEqual({
-      selectedWorks: [stubWork],
-      searchedWorks: [[stubWork], [stubWork]],
-      selectedWork: stubWork,
-      selectedReviews: [stubReview],
       recWorkLists: [[stubWork]],
     });
   });
 
   it('should get searched works', () => {
     const stubInitialState = {
-      selectedWorks: [stubWork],
-      searchedWorks: [[stubWork], [stubWork]],
-      selectedWork: stubWork,
-      selectedReviews: [stubReview],
+      searchedWorks: [[], []],
     };
     const newState = reducer(stubInitialState, {
       type: actionTypes.GET_SEARCH_WORKS,
-      selectedWorks: [[stubWork], [stubWork]],
+      selectedWorks: [[stubWork], [stubWork, stubWork]],
     });
     expect(newState).toEqual({
-      selectedWorks: [stubWork],
-      searchedWorks: [[stubWork], [stubWork]],
-      selectedWork: stubWork,
-      selectedReviews: [stubReview],
+      searchedWorks: [[stubWork], [stubWork, stubWork]],
     });
   });
 


### PR DESCRIPTION
간단히 요약하면, user reducer에 있었던 `GET_MY_REVIEWS`, work reducer에 있던 `GET_WORK_REVIEWS`, 그리고 review reducer에 있었던 `GET_BOARD_REVIEWS`를 합쳐서 review reducer의 `GET_REVIEWS`가 셋 모두의 역할을 하도록 만들었습니다. 그러나 action을 부를 때 `actionCreator.getBoardReviews`, `actionCreator.getWorkReviews`, `actionCreator.getMyReviews` 등은 그대로 사용할 수 있도록, 이름은 유지한 채 위치만 review action으로 옮겨 새로 정의했습니다. 
이 과정에서 state가 달라짐에 따라, 여러 테스트를 일부 수정하였습니다. 
redux를 사용하는 입장에서 달라진 점은, review들을 `mapStateToProps`를 통해 가져올 때 기존에는 `boardReviews: state.review.boardReviews`로 가져왔다면, state의 이름을 통합하게 되어 이제는 `boardReviews: state.review.reveiws`로 가져와야 한다는 것만 달라졌습니다. `mapDispatchToProps` 등 나머지는 다 똑같습니다. 

이 리팩토링이 성립하는 전제 조건은 GET /users/me/reivews/의 response.data 형태와, GET /works/:id/reviews/의 response.data 형태와, GET /reviews/board/의 response.data 형태가 모두 `{ reviews: [Review] }`의 형태를 갖는 것입니다. 현재까지는 성립하고, 앞으로 api가 크게 변하지 않는 이상 쭉 괜찮을 것 같습니다. 

아 그리고 GET /reviews/:id/가 쓸데가 없는거 같아서...? 백엔 api는 아직 안 지웠는데 프엔에서 이걸 이용하는 GET_REVIEW action은 지웠습니다. 혹시 이 액션이 쓸데가 있었다면... 음... 제게 마구 욕을 해주시면 되겠습니다. 그럼 이만...